### PR TITLE
aptkit: fix syntax warning errors in python 3.12 and 3.13

### DIFF
--- a/aptkit/core.py
+++ b/aptkit/core.py
@@ -93,12 +93,12 @@ TRANSACTION_DEL_TIMEOUT = 30
 
 # regexp for the pkgname and optional arch, for details see
 #   http://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Source
-REGEX_VALID_PACKAGENAME = "^[a-z0-9][a-z0-9\-+.]+(:[a-z0-9]+)?$"
+REGEX_VALID_PACKAGENAME = r"^[a-z0-9][a-z0-9\-+.]+(:[a-z0-9]+)?$"
 # regexp for the version number, for details see:
 #   http://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version
-REGEX_VALID_VERSION = "^[0-9][0-9.+\-A-Za-z:~]*$"
+REGEX_VALID_VERSION = r"^[0-9][0-9.+\-A-Za-z:~]*$"
 # regexp for the archive (Suite) as found in the Release file
-REGEX_VALID_RELEASE = "^[a-zA-Z0-9_\-\.]+$"
+REGEX_VALID_RELEASE = r"^[a-zA-Z0-9_\-\.]+$"
 
 # Setup the DBus main loop
 dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)

--- a/aptkit/progress.py
+++ b/aptkit/progress.py
@@ -54,7 +54,7 @@ MAP_DPKG_STAGE = {"install": enums.PKG_INSTALLING,
                   "disappear": enums.PKG_DISAPPEARING,
                   "upgrade": enums.PKG_UPGRADING}
 
-REGEX_ANSI_ESCAPE_CODE = chr(27) + "\[[;?0-9]*[A-Za-z]"
+REGEX_ANSI_ESCAPE_CODE = chr(27) + r"\[[;?0-9]*[A-Za-z]"
 
 
 class DaemonOpenProgress(apt.progress.base.OpProgress):
@@ -657,7 +657,7 @@ class DaemonInstallProgress(DaemonForkProgress):
         elif status == "pmconffile":
             # we get a string like this:
             # 'current-conffile' 'new-conffile' useredited distedited
-            match = re.match("\s*\'(.*)\'\s*\'(.*)\'.*", message_raw)
+            match = re.match(r"\s*\'(.*)\'\s*\'(.*)\'.*", message_raw)
             if match:
                 new, old = match.group(1), match.group(2)
                 self._conffile(new, old)
@@ -781,7 +781,7 @@ class DaemonDpkgInstallProgress(DaemonInstallProgress):
             if status[2] == "error":
                 self._error(status[1], status[3])
             elif status[2] == "conffile":
-                match = re.match("\s*\'(.*)\'\s*\'(.*)\'.*", status[3])
+                match = re.match(r"\s*\'(.*)\'\s*\'(.*)\'.*", status[3])
                 if match:
                     new, old = match.group(1), match.group(2)
                     self._conffile(new, old)

--- a/aptkit/worker/aptworker.py
+++ b/aptkit/worker/aptworker.py
@@ -459,7 +459,7 @@ class AptWorker(BaseWorker):
         else:
             sourcesfile = None
         # Store any private login information in a separate auth.conf file
-        if re.match("(http|https|ftp)://\S+?:\S+?@\S+", uri):
+        if re.match(r"(http|https|ftp)://\S+?:\S+?@\S+", uri):
             uri = self._store_and_strip_password_from_uri(uri)
             auth_conf_path = apt_pkg.config.find_file("Dir::etc::netrc")
             if not comment:

--- a/aptkit/worker/pkworker.py
+++ b/aptkit/worker/pkworker.py
@@ -90,7 +90,7 @@ MATCH_BUG_CLOSES_UBUNTU = r"lp:\s+\#\d+(?:,\s*\#\d+)*"
 HREF_BUG_UBUNTU = "https://bugs.launchpad.net/bugs/%s"
 
 # Regular expression to find cve references
-MATCH_CVE = "CVE-\d{4}-\d{4}"
+MATCH_CVE = r"CVE-\d{4}-\d{4}"
 HREF_CVE = "http://web.nvd.nist.gov/view/vuln/detail?vulnId=%s"
 
 # Map Debian sections to the PackageKit group name space
@@ -326,9 +326,9 @@ class AptPackageKitWorker(aptworker.AptWorker):
             filenames_regex = []
             for filename in values:
                 if filename.startswith("/"):
-                    pattern = "^%s$" % filename[1:].replace("/", "\/")
+                    pattern = "^%s$" % filename[1:].replace("/", r"\/")
                 else:
-                    pattern = "\/%s$" % filename
+                    pattern = r"\/%s$" % filename
                 filenames_regex.append(pattern)
             cmd = ["/usr/bin/apt-file", "--regexp", "--non-interactive",
                    "--package-only", "find", "|".join(filenames_regex)]
@@ -351,9 +351,9 @@ class AptPackageKitWorker(aptworker.AptWorker):
         filenames_regex = []
         for filename in values:
             if filename.startswith("/"):
-                pattern = "^%s$" % filename.replace("/", "\/")
+                pattern = "^%s$" % filename.replace("/", r"\/")
             else:
-                pattern = ".*\/%s$" % filename
+                pattern = r".*\/%s$" % filename
             filenames_regex.append(pattern)
         files_pattern = re.compile("|".join(filenames_regex))
         for pkg in self._iterate_packages():
@@ -661,8 +661,8 @@ class AptPackageKitWorker(aptworker.AptWorker):
                 elif line.startswith(" --"):
                     # FIXME: Add %z for the time zone - requires Python 2.6
                     update_text += "  \n"
-                    match = re.match("^ -- (?P<maintainer>.+) (?P<mail><.+>)  "
-                                     "(?P<date>.+) (?P<offset>[-\+][0-9]+)$",
+                    match = re.match(r"^ -- (?P<maintainer>.+) (?P<mail><.+>)  "
+                                     r"(?P<date>.+) (?P<offset>[-\+][0-9]+)$",
                                      line)
                     if not match:
                         continue


### PR DESCRIPTION
just syntax deprecation fixes such as:
```
/usr/lib/python3/dist-packages/aptkit/core.py:96: SyntaxWarning: invalid escape sequence '\-'
  REGEX_VALID_PACKAGENAME = "^[a-z0-9][a-z0-9\-+.]+(:[a-z0-9]+)?$"
/usr/lib/python3/dist-packages/aptkit/core.py:99: SyntaxWarning: invalid escape sequence '\-'
  REGEX_VALID_VERSION = "^[0-9][0-9.+\-A-Za-z:~]*$"
/usr/lib/python3/dist-packages/aptkit/core.py:101: SyntaxWarning: invalid escape sequence '\-'
  REGEX_VALID_RELEASE = "^[a-zA-Z0-9_\-\.]+$"
/usr/lib/python3/dist-packages/aptkit/progress.py:57: SyntaxWarning: invalid escape sequence '\['
  REGEX_ANSI_ESCAPE_CODE = chr(27) + "\[[;?0-9]*[A-Za-z]"
/usr/lib/python3/dist-packages/aptkit/progress.py:660: SyntaxWarning: invalid escape sequence '\s'
  match = re.match("\s*\'(.*)\'\s*\'(.*)\'.*", message_raw)
/usr/lib/python3/dist-packages/aptkit/progress.py:784: SyntaxWarning: invalid escape sequence '\s'
  match = re.match("\s*\'(.*)\'\s*\'(.*)\'.*", status[3])
/usr/lib/python3/dist-packages/aptkit/worker/aptworker.py:462: SyntaxWarning: invalid escape sequence '\S'
  if re.match("(http|https|ftp)://\S+?:\S+?@\S+", uri):
/usr/lib/python3/dist-packages/aptkit/worker/pkworker.py:93: SyntaxWarning: invalid escape sequence '\d'
  MATCH_CVE = "CVE-\d{4}-\d{4}"
/usr/lib/python3/dist-packages/aptkit/worker/pkworker.py:329: SyntaxWarning: invalid escape sequence '\/'
  pattern = "^%s$" % filename[1:].replace("/", "\/")
/usr/lib/python3/dist-packages/aptkit/worker/pkworker.py:331: SyntaxWarning: invalid escape sequence '\/'
  pattern = "\/%s$" % filename
/usr/lib/python3/dist-packages/aptkit/worker/pkworker.py:354: SyntaxWarning: invalid escape sequence '\/'
  pattern = "^%s$" % filename.replace("/", "\/")
/usr/lib/python3/dist-packages/aptkit/worker/pkworker.py:356: SyntaxWarning: invalid escape sequence '\/'
  pattern = ".*\/%s$" % filename
/usr/lib/python3/dist-packages/aptkit/worker/pkworker.py:665: SyntaxWarning: invalid escape sequence '\+'
  "(?P<date>.+) (?P<offset>[-\+][0-9]+)$",

```