### PR TITLE
simpleclient: Preserve the "#auto" install marker through local depen…

### DIFF
--- a/aptkit/simpleclient.py
+++ b/aptkit/simpleclient.py
@@ -44,8 +44,13 @@ class SimpleAPTClient(object):
             # Use the resolver from python-apt
             # it works better in complex scenarios
             # mark the packages as mark_install
+            # Package names may carry an explicit "#auto" suffix (see
+            # aptworker._mark_packages_for_installation()) telling the worker to
+            # record them as automatically installed rather than manual. Strip it
+            # for the cache lookups below, since apt itself doesn't know about it.
+            requested_names = [name.partition("#")[0] for name in packages]
             cache = apt.Cache()
-            for name in packages:
+            for name in requested_names:
                 try:
                     pkg = cache[name]
                     pkg.mark_install()
@@ -55,8 +60,12 @@ class SimpleAPTClient(object):
             # via cache.get_changes()
             changes = cache.get_changes()
             for pkg in changes:
-                if pkg.marked_install and pkg.name not in packages:
-                    packages.append(pkg.name)
+                if pkg.marked_install and pkg.name not in requested_names:
+                    # Not explicitly requested, just pulled in as a dependency
+                    # (e.g. a kernel image pulled in by a meta package): flag it
+                    # as automatic so it stays eligible for autoremoval, same as
+                    # a normal "apt install"/"apt upgrade" would leave it.
+                    packages.append(pkg.name + "#auto")
 
         client = aptkit.client.AptClient()
         client.install_packages(packages, reply_handler=self._simulate_trans, error_handler=self._on_error)


### PR DESCRIPTION
Related: linuxmint/mintupdate#938 and linuxmint/mintupdate#1078

## Summary

Companion fix to a mintupdate change (https://github.com/linuxmint/mintupdate, branch: autoremove-kernel-fix) that fixes `apt autoremove` never cleaning up old kernels installed via mintupdate.  PR linuxmint/mintupdate#1081

## Root cause

`aptworker._mark_packages_for_installation()` already supports an opt-in convention for callers: a package name suffixed with `#auto` (e.g. `"linux-image-6.17.0-41-generic#auto"`) is installed with `from_user=False`, i.e. recorded as automatically installed rather than manually installed. This is what lets a caller install a specific package by name while still leaving it eligible for `apt autoremove` later, matching how apt would treat it if it had been pulled in as a dependency instead.

`SimpleAPTClient.install_packages()` undermines this. Before handing the package list to the worker over D-Bus, it does a local `apt.Cache()` dependency resolution pass to discover any additional packages a request will pull in (e.g. a kernel image pulled in by a meta package upgrade), and appends their bare names to the same `packages` list:

    for pkg in changes:
        if pkg.marked_install and pkg.name not in packages:
            packages.append(pkg.name)

None of these names carry the `#auto` suffix, so every package in the flattened list — both the ones the caller explicitly asked for and the ones only pulled in as a dependency — ends up marked manually installed by the worker. This defeats the purpose of the `#auto` convention entirely: even a caller that tags its own request with `#auto` gets nothing, since the local resolver strips out whatever wasn't an exact literal package name in the original list in the first place, and anything it discovers is re-added without the tag.

## History

The flattening step was introduced in 18d255f ("simpleclient: Use python-apt resolver when installing pkgs", 2024-09-11), days before mintupdate 7.0.0 switched its installs from synaptic to aptkit. The combination is what regressed kernel autoremoval for mintupdate users: under synaptic (and under aptkit without the flattening), dependency packages were marked automatically installed by the resolver, so superseded kernels remained autoremovable. The "#auto" convention itself predates the fork - it was inherited from aptdaemon in the initial aptkit import (April 2022) and validated at the D-Bus boundary all along, but no client ever used it.

## Fix

- Compute `requested_names` by stripping any `#auto` suffix before   doing the local `apt.Cache()` lookups (apt itself doesn't know about the suffix convention), so callers can pass pre-tagged names through `install_packages()` without breaking the resolution step.
- Newly-discovered dependency packages (present in `cache.get_changes()` but not in the caller's original request) are now tagged `#auto` themselves before being appended, since by definition they were resolved rather than explicitly requested — matching what a normal `apt install`/`apt upgrade` would leave them as.

## Behavior change for all SimpleAPTClient consumers

Note that the second part affects every caller of `SimpleAPTClient.install_packages()` (mintinstall, driver manager, ...), not just mintupdate: dependency packages pulled in alongside a requested package are now recorded as automatically installed, where previously the flattening step left them manually installed. This moves aptkit toward standard apt semantics — after a plain `apt install foo`, foo's dependencies are marked auto and become autoremovable once nothing needs them — so e.g. libraries installed alongside an application can now be reclaimed by `apt autoremove` after the application is removed, instead of lingering forever. Callers that genuinely want a dependency pinned as manual can still request it explicitly by name.

## Testing

Manually tested as part of the mintupdate branch above: with this change plus the mintupdate-side tagging, `apt-mark showauto` shows newly-installed kernel packages as automatic (previously all showed as manual), and `apt-get autoremove --dry-run` / `apt autoremove` correctly identify and reclaim superseded kernel packages while leaving the running kernel untouched.

No test suite exists in this repo to extend.

Claude Fable 5 was used to fix these issues.